### PR TITLE
refactor(Launcher): Uses `Path` instead of `String` for filepath

### DIFF
--- a/src/utils/launch.rs
+++ b/src/utils/launch.rs
@@ -1,4 +1,5 @@
 use crate::constants::*;
+use crate::structs::libraries::Libraries;
 use crate::structs::*;
 use crate::utils::files;
 use crossbeam_channel::Sender;
@@ -7,9 +8,15 @@ use reqwest;
 use std::fs::{create_dir_all, File};
 use std::io::Read;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::Ordering;
+
+const LIB_SEPARATOR: &str = if cfg!(target_os = "windows") {
+    ";"
+} else {
+    ":"
+};
 
 pub async fn prepare_game(profile_id: &str, sender: Sender<String>) {
     let username = {
@@ -80,51 +87,44 @@ pub async fn prepare_game(profile_id: &str, sender: Sender<String>) {
     .await;
 }
 
-pub fn gen_libs_path(path: &str, profile: &str) -> Option<String> {
+/// Loads the librairies from the given profile
+fn load_game_libs(profile: &str) -> Libraries {
+    let mut file = File::open(format!("{}/version.json", profile)).unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    serde_json::from_str(&contents).unwrap()
+}
+
+// Lists all the librairies needed to launch the game
+fn list_libs_path(path: &str, profile: &str) -> Option<Vec<PathBuf>> {
     let libs_path = Path::new(path);
 
     if !libs_path.exists() || libs_path.is_file() {
         return None;
     }
 
-    let mut file = File::open(format!("{}/version.json", profile)).unwrap();
-    let mut contents = String::new();
-    file.read_to_string(&mut contents).unwrap();
-    let version: libraries::Libraries = serde_json::from_str(&contents).unwrap();
-
-    let mut libs = String::new();
-
-    let sep = if cfg!(target_os = "windows") {
-        ";"
-    } else {
-        ":"
-    };
+    let version = load_game_libs(profile);
+    let mut libs = Vec::new();
 
     for lib in version.libraries.iter() {
         match &lib.downloads.artifact {
             Some(artifact) => {
                 let artifact_path = artifact.path.to_owned().unwrap();
-                let file_name = artifact_path.split('/').last().unwrap();
+                let file_name = &artifact_path.split('/').last().unwrap();
 
-                libs.push_str(format!("{}/{}/{}{}", path, artifact_path, file_name, sep).as_str());
+                libs.push(libs_path.join(&artifact_path).join(file_name));
             }
             None => {}
         }
 
         if let Some(natives) = lib.downloads.get_natives() {
             let natives_path = natives.path.to_owned().unwrap();
-            let file_name = natives_path.split('/').last().unwrap();
+            let file_name = &natives_path.split('/').last().unwrap();
 
-            libs.push_str(format!("{}/{}/{}{}", path, natives_path, file_name, sep).as_str());
+            libs.push(libs_path.join(&natives_path).join(file_name));
         }
     }
 
-    libs = libs.trim_end_matches(sep).to_string();
-
-    // FIXME: use path bufs (?) or something smarter
-    if cfg!(target_os = "windows") {
-        libs = libs.replace("/", "\\");
-    }
     Some(libs)
 }
 
@@ -142,23 +142,24 @@ pub async fn gen_run_cmd(
         .unwrap();
 
     let dot = std::env::var("DOT_MCTUI").unwrap();
+    let base_dir = Path::new(&dot);
+    let profile_dir = Path::new(&profile);
 
-    let mut libs = gen_libs_path(format!("{}/libs", dot).as_str(), profile).unwrap();
-    let mut assets = format!("{}/assets", dot);
-    let mut game_dir = format!("{}/game", profile);
-    let mut sep = ":";
+    let mut libs = list_libs_path(format!("{}/libs", dot).as_str(), profile).unwrap();
+    libs.push(profile_dir.join("client.jar"));
 
-    // FIXME: use path bufs (?) or something smarter
-    if cfg!(target_os = "windows") {
-        libs = libs.replace("/", "\\");
-        assets = assets.replace("/", "\\");
-        game_dir = game_dir.replace("/", "\\");
-        sep = ";";
-    }
+    let assets = base_dir.join("assets");
+    let game_dir = profile_dir.join("game");
 
     create_dir_all(game_dir.to_owned()).unwrap();
 
     let mut args = args.split(' ').map(|a| a.to_owned()).collect::<Vec<_>>();
+
+    let libs_args = libs
+        .iter()
+        .map(|x| x.to_string_lossy().to_string())
+        .collect::<Vec<String>>()
+        .join(LIB_SEPARATOR);
 
     let additional_arguments = [
         "-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump"
@@ -167,14 +168,14 @@ pub async fn gen_run_cmd(
         "-Dminecraft.launcher.brand=java-minecraft-launcher".to_string(),
         "-Dminecraft.launcher.version=1.6.89-j".to_string(),
         "-cp".to_string(),
-        format!("{}{}{}/client.jar", libs, sep, profile),
+        libs_args,
         "net.minecraft.client.main.Main".to_string(),
         format!("--username={}", username),
         format!("--version='{} MCTui'", version),
         "--accessToken=0".to_string(),
         // "--userProperties={{}}".to_string(),
-        format!("--gameDir={}", game_dir),
-        format!("--assetsDir={}", assets),
+        format!("--gameDir={}", game_dir.to_string_lossy()),
+        format!("--assetsDir={}", assets.to_string_lossy()),
         format!("--assetIndex={}", asset_index),
         "--width=1280".to_string(),
         "--height=720".to_string(),


### PR DESCRIPTION
Convert all launcher files representation form `String` to `Path` in order to make them OS independent.

@Noituri I've only tested this on Linux, I do not have Windows or MacOS so I cannot test on those platform, but it should works.
